### PR TITLE
Adds support for pinning comments or packages to the top of the sort. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
   * `package` - Any import path that does not begin with `.`
   * `relativeUpLevel` - Any import path that begins with `../`
   * `relativeDownLevel` - Any import path that begins with `./`
+* `typescript.extension.sortImports.pathSortOrderOverride`: An array describing the order of packages that when sorting imports, should be excluded from the system, and instead moved to the top of the import list in order, packages should be expressed by path.
 * `typescript.extension.sortImports.quoteStyle`: The type of quotation mark to use. `single`(default) or `double`.
 * `typescript.extension.sortImports.sortMethod`: The method to use for sorting the imports.
   * `'importName'`(default) sorts by the type and name of the import. Namespace imports are first, followed by default imports, named imports, and unnamed imports.
@@ -57,6 +58,9 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
 - Maybe none of these. ¯\\_(ツ)_/¯
 
 ## Release Notes
+
+## 1.14.0
+- add support for overriding the import sort order, as requred by [Issue #](https://github.com/neilsoult/typescript-imports-sort/issues/12)
 
 ## 1.13.0
 - added support for tilde (`~`) character starting import path strings, as requested by [Issue #9](https://github.com/neilsoult/typescript-imports-sort/issues/9)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This configurable extension allows you to sort all the imports in a *.ts or *.ts
 
 ## 1.14.0
 - add support for overriding the import sort order, as requred by [Issue #](https://github.com/neilsoult/typescript-imports-sort/issues/12)
+- add support for comments or code before the import block, as requred by [Issue #](https://github.com/neilsoult/typescript-imports-sort/issues/12)
 
 ## 1.13.0
 - added support for tilde (`~`) character starting import path strings, as requested by [Issue #9](https://github.com/neilsoult/typescript-imports-sort/issues/9)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-imports-sort",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-imports-sort",
   "displayName": "Typescript Imports Sort",
   "description": "Sorts import statements in Typescript code",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "publisher": "nsoult",
   "license": "MIT",
   "icon": "images/icon.png",
@@ -113,6 +113,15 @@
             "relativeUpLevel",
             "package"
           ]
+        },
+        "typescript.extension.sortImports.pathSortOrderOverride": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "When sorting imports, this controls which packages should be excluded from the system, and instead moved to the top of the import list in order, packages should be expressed by path",
+          "default": []
         },
         "typescript.extension.sortImports.quoteStyle": {
           "type": "string",

--- a/src/core/interfaces/options.ts
+++ b/src/core/interfaces/options.ts
@@ -12,6 +12,7 @@ export interface ExtensionOptions {
     multilineIndention: MultilineIndentionOption;
     omitSemicolon: boolean;
     pathSortOrder: PathSortOrderOption[];
+    pathSortOrderOverride: string[];
     quoteStyle: 'double' | 'single';
     sortMethod: SortMethodOption;
     sortOnSave: boolean;

--- a/src/core/process-imports/index.ts
+++ b/src/core/process-imports/index.ts
@@ -1,1 +1,2 @@
 export * from './process-imports';
+export * from './process-imports-overrides'

--- a/src/core/process-imports/process-imports-overrides.ts
+++ b/src/core/process-imports/process-imports-overrides.ts
@@ -1,0 +1,18 @@
+import { TypescriptImport } from '../interfaces';
+import { options } from '../options/index';
+
+export const processImportsOverrides = (importClauses: TypescriptImport[]): TypescriptImport[] => {
+  if (options.get('pathSortOrderOverride') && options.get('pathSortOrderOverride').length > 0) {
+    options.get('pathSortOrderOverride').reverse().forEach(p => {
+      if (importClauses.some(i => i.path === p)) {
+        const originalImports = importClauses.filter(i => i.path != p)
+        const priorityImports = importClauses.filter(i => i.path === p)
+        importClauses.length = 0;
+        importClauses.push(...priorityImports)
+        importClauses.push(...originalImports)
+      }
+    })
+  }
+
+  return importClauses
+};

--- a/src/core/sort/sort-imports.ts
+++ b/src/core/sort/sort-imports.ts
@@ -12,8 +12,23 @@ export const sortImports = (document: vscode.TextDocument) => {
         return vscode.TextEdit.delete(importClause.range);
 
     });
-    edits.push(vscode.TextEdit.insert(new vscode.Position(0, 0), sortedImportText));
+
+    edits.push(vscode.TextEdit.insert(getImportsStartPosition(document), sortedImportText));
 
     return edits;
 
 };
+
+function getImportsStartPosition(document: vscode.TextDocument) {
+    let importStartIndex = 0;
+    for (let index = 0; index < document.lineCount; index++) {
+        const line = document.lineAt(index);
+
+        if ( line.text.startsWith('import')) {
+            importStartIndex = index;
+            break;
+        }
+    }
+    
+    return new vscode.Position(importStartIndex, 0);
+}

--- a/src/core/sort/sort-imports.ts
+++ b/src/core/sort/sort-imports.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 import { parseImportNodes } from './parse-import-nodes';
-import { processImports } from '../process-imports';
+import { processImports, processImportsOverrides } from '../process-imports';
 import { writeImports } from '../write-imports';
 
 export const sortImports = (document: vscode.TextDocument) => {
 
-    const imports = processImports(parseImportNodes(document));
+    const imports = processImportsOverrides(processImports(parseImportNodes(document)));
     const sortedImportText = writeImports(imports);
     const edits: vscode.TextEdit[] = imports.map((importClause) => {
 


### PR DESCRIPTION
This resolves neilsoult/typescript-imports-sort#12 by allowing an array of packages to be placed at the top of the sorted imports. 
It also allows for single or multiline comments as well as code to be placed before the imports block. 

Please note this does not support comments within the imports block. 